### PR TITLE
Feat/Add support for in-memory BytesIO GeoJSON in basemapper.py

### DIFF
--- a/osm_fieldwork/basemapper.py
+++ b/osm_fieldwork/basemapper.py
@@ -26,6 +26,7 @@ import queue
 import re
 import sys
 import threading
+from io import BytesIO
 from pathlib import Path
 from typing import Union
 
@@ -47,6 +48,7 @@ from shapely.geometry import shape
 from shapely.ops import unary_union
 
 from osm_fieldwork.sqlite import DataFile, MapTile
+from osm_fieldwork.utils import read_bytes_geojson
 from osm_fieldwork.xlsforms import xlsforms_path
 from osm_fieldwork.yamlfile import YamlFile
 
@@ -125,7 +127,7 @@ class BaseMapper(object):
 
     def __init__(
         self,
-        boundary: str,
+        boundary: Union[str, BytesIO],
         base: str,
         source: str,
         xy: bool,
@@ -133,7 +135,7 @@ class BaseMapper(object):
         """Create an tile basemap for ODK Collect.
 
         Args:
-            boundary (str): A BBOX string or GeoJSON file of the AOI.
+            boundary (union[str, bytesIO ]): A BBOX string or GeoJSON file as a ByteIO representing the AOI.
                 The GeoJSON can contain multiple geometries.
             base (str): The base directory to cache map tile in
             source (str): The upstream data source for map tiles
@@ -283,8 +285,7 @@ class BaseMapper(object):
         Returns:
             (list): The bounding box coordinates
         """
-        if not boundary.lower().endswith((".json", ".geojson")):
-            # Is BBOX string
+        if not isinstance(boundary, BytesIO):
             try:
                 if "," in boundary:
                     bbox_parts = boundary.split(",")
@@ -304,9 +305,11 @@ class BaseMapper(object):
                 log.error(msg)
                 raise ValueError(msg) from None
 
-        log.debug(f"Reading geojson file: {boundary}")
-        with open(boundary, "r") as f:
-            poly = geojson.load(f)
+        log.debug(f"Reading geojson BytesIO : {boundary}")
+        boundary.seek(0)
+        with boundary as buffer:
+            poly = geojson.load(buffer)
+
         if "features" in poly:
             geometry = shape(poly["features"][0]["geometry"])
         elif "geometry" in poly:
@@ -576,7 +579,7 @@ def main():
             log.error("")
             parser.print_help()
             quit()
-        boundary_parsed = args.boundary[0]
+        boundary_parsed = read_bytes_geojson(args.boundary[0])
     elif len(args.boundary) == 4:
         boundary_parsed = ",".join(args.boundary)
     else:

--- a/osm_fieldwork/utils.py
+++ b/osm_fieldwork/utils.py
@@ -1,0 +1,8 @@
+import io
+
+def read_bytes_geojson(file_path):
+    with open(file_path, "rb") as geojson_file:
+        geojson_bytes = geojson_file.read()  # read as a `bytes` object.
+        geojson_bytes_io = io.BytesIO(geojson_bytes)  # add to a BytesIO wrapper
+
+    return geojson_bytes_io

--- a/outreachy.py
+++ b/outreachy.py
@@ -1,0 +1,14 @@
+import os
+from osm_fieldwork.basemapper import create_basemap_file,BaseMapper
+from osm_fieldwork.utils import read_bytes_geojson
+
+GEOJSON_FILEPATH = "tests/testdata/Rollinsville.geojson"
+boundary = read_bytes_geojson(GEOJSON_FILEPATH)
+
+create_basemap_file(
+    verbose=True,
+    boundary=boundary,
+    outfile="outreachy.mbtiles",
+    zooms="12-15",
+    source="esri",
+)

--- a/tests/test_basemap.py
+++ b/tests/test_basemap.py
@@ -25,11 +25,12 @@ import shutil
 
 from osm_fieldwork.basemapper import BaseMapper
 from osm_fieldwork.sqlite import DataFile
+from osm_fieldwork.utils import read_bytes_geojson
 
 log = logging.getLogger(__name__)
 
 rootdir = os.path.dirname(os.path.abspath(__file__))
-boundary = f"{rootdir}/testdata/Rollinsville.geojson"
+boundary = read_bytes_geojson(f"{rootdir}/testdata/Rollinsville.geojson")
 outfile = f"{rootdir}/testdata/rollinsville.mbtiles"
 base = "./tiles"
 # boundary = open(infile, "r")


### PR DESCRIPTION
This pull request addresses issue #204 by enhancing the `basemapper.py` module to support in-memory BytesIO GeoJSON for the `boundary` parameter. Additionally, a utility function `read_bytes_geojson` in `utils.py` has been introduced to handle GeoJSON as BytesIO.

**Changes Made**

- Modified `basemapper.py` to accept BytesIO GeoJSON for the `boundary` parameter.
- Introduced `utils.py` with `read_bytes_geojson` function.
- Updated `test_basemap.py` to utilize the new utility function.

 **Testing**

Tested the changes locally using PDM and ensured compatibility with existing tests.
checked for issues using this code ( pre-commit run --files osm_fieldwork/basemapper.py )

**Related Issues**

Closes #204
