### PR TITLE
Handle non-string boundaries and add test cases for BaseMapper class

### DIFF
--- a/osm_fieldwork/basemapper.py
+++ b/osm_fieldwork/basemapper.py
@@ -283,27 +283,32 @@ class BaseMapper(object):
         Returns:
             (list): The bounding box coordinates
         """
-        if not boundary.lower().endswith((".json", ".geojson")):
-            # Is BBOX string
-            try:
-                if "," in boundary:
-                    bbox_parts = boundary.split(",")
-                else:
-                    bbox_parts = boundary.split(" ")
-                bbox = tuple(float(x) for x in bbox_parts)
-                if len(bbox) == 4:
-                    # BBOX valid
-                    return bbox
-                else:
-                    msg = f"BBOX string malformed: {bbox}"
+        if isinstance(boundary, str):
+            if not boundary.lower().endswith((".json", ".geojson")):
+                # Is BBOX string
+                try:
+                    if "," in boundary:
+                        bbox_parts = boundary.split(",")
+                    else:
+                        bbox_parts = boundary.split(" ")
+                    bbox = tuple(float(x) for x in bbox_parts)
+                    if len(bbox) == 4:
+                        # BBOX valid
+                        return bbox
+                    else:
+                        msg = f"BBOX string malformed: {bbox}"
+                        log.error(msg)
+                        raise ValueError(msg) from None
+                except Exception as e:
+                    log.error(e)
+                    msg = f"Failed to parse BBOX string: {boundary}"
                     log.error(msg)
                     raise ValueError(msg) from None
-            except Exception as e:
-                log.error(e)
-                msg = f"Failed to parse BBOX string: {boundary}"
-                log.error(msg)
-                raise ValueError(msg) from None
-
+        else:
+            msg =f"Boundary expects string: {boundary}"
+            log.error(msg)
+            raise ValueError(msg) from None
+            
         log.debug(f"Reading geojson file: {boundary}")
         with open(boundary, "r") as f:
             poly = geojson.load(f)

--- a/tests/test_basemap.py
+++ b/tests/test_basemap.py
@@ -22,49 +22,152 @@
 import logging
 import os
 import shutil
+import pytest
 
-from osm_fieldwork.basemapper import BaseMapper
+from osm_fieldwork.basemapper import BaseMapper,create_basemap_file
 from osm_fieldwork.sqlite import DataFile
 
 log = logging.getLogger(__name__)
+ROOTDIR = os.path.dirname(os.path.abspath(__file__))
 
-rootdir = os.path.dirname(os.path.abspath(__file__))
-boundary = f"{rootdir}/testdata/Rollinsville.geojson"
-outfile = f"{rootdir}/testdata/rollinsville.mbtiles"
-base = "./tiles"
-# boundary = open(infile, "r")
-# poly = geojson.load(boundary)
-# if "features" in poly:
-#    geometry = shape(poly["features"][0]["geometry"])
-# elif "geometry" in poly:
-#    geometry = shape(poly["geometry"])
-# else:
-#    geometry = shape(poly)
+class TestBaseMap:
 
+    def setup_method(self):
+        self.outfile = f"{ROOTDIR}/testdata/rollinsville.mbtiles"
+        self.boundary= f"{ROOTDIR}/testdata/Rollinsville.geojson"
+        self.base = "./tiles"
+    def teardown_method(self):
+        pass
 
-def test_create():
-    """See if the file got loaded."""
-    hits = 0
-    basemap = BaseMapper(boundary, base, "topo", False)
-    tiles = list()
-    for level in [8, 9, 10, 11, 12]:
-        basemap.getTiles(level)
-        tiles += basemap.tiles
+    def create_basemap(self, base= "./tiles", source= "topo", xy=False):
+        return BaseMapper(self.boundary, base, source, xy)
 
-    if len(tiles) == 5:
-        hits += 1
+    def test_reading_geojson_and_loading_boundary(self):
+        """
+        Test reading GeoJSON and loading boundary.
 
-    if tiles[0].x == 52 and tiles[1].y == 193 and tiles[2].x == 211:
-        hits += 1
+        This function tests the reading of GeoJSON and the loading of boundary using the BaseMapper class.
+        It verifies if the boundary is correctly loaded from the GeoJSON file and stored as a tuple.
 
-    outf = DataFile(outfile, basemap.getFormat())
-    outf.writeTiles(tiles, base)
+        Test Cases:
+        - Test if the GeoJSON file is read and boundary is loaded.
+        - Test if the loaded boundary is stored as a tuple.
 
-    os.remove(outfile)
-    shutil.rmtree(base)
+        """
+        basemap = self.create_basemap()
+        assert isinstance(basemap.bbox, tuple)
 
-    assert hits == 2
+    def test_create_basemap_and_tiles(self):
+        """See if the file got loaded."""
+        hits = 0
+        tiles = list()
+        basemap = self.create_basemap()
+        for level in [8, 9, 10, 11, 12]:
+            basemap.getTiles(level)
+            tiles +=basemap.tiles
 
+        if len(tiles) == 5:
+            hits += 1
 
-if __name__ == "__main__":
-    test_create()
+        if tiles[0].x == 52 and tiles[1].y == 193 and tiles[2].x == 211:
+            hits += 1
+
+        outf = DataFile(self.outfile, basemap.getFormat())
+        outf.writeTiles(tiles, self.base)
+
+        os.remove(self.outfile)
+        shutil.rmtree(self.base)
+
+        assert hits == 2
+        
+    def test_load_boundary_with_bbox(self):
+        """
+        Test loading boundary with BBOX string and with space.
+
+        This function tests the loading of boundary with BBOX string that contains coordinates separated by commas
+        and with coordinates separated by spaces.
+
+        Test Cases:
+        - Test loading boundary with BBOX string separated by commas.
+        - Test loading boundary with BBOX string separated by spaces.
+
+        """
+        comma_bbox_str="-209.519, 35.909, -209.504, 37.925"
+        basemap = BaseMapper(comma_bbox_str, self.base, "topo", False)
+        assert isinstance(basemap.bbox, tuple)
+
+        space_bbox_str="-209.519 35.909 -209.504 37.925"
+        basemap = BaseMapper(space_bbox_str, self.base, "topo", False)
+        assert isinstance(basemap.bbox, tuple)
+
+    def test_invalid_boundaries(self):
+        """
+        Test invalid boundary inputs.
+
+        This function tests various invalid inputs for boundary parameter initialization
+        in the BaseMapper class. It ensures that ValueError is raised for each invalid
+        boundary input.
+
+        Raises:
+        - ValueError: If an invalid boundary is provided during initialization.
+        """
+        invalid_boundaries = [
+            None, 
+            "",  
+            "invalid_bbox_string",
+            "1,2,3,A",
+            "3,5,b",
+            " 1,2,3",
+            123,  
+            [1, 2, 3, 4, 5],
+        ]
+
+        for boundary_value in invalid_boundaries:
+            with pytest.raises(ValueError):
+                # Attempt to initialize BaseMapper with invalid boundary
+                BaseMapper(boundary_value, "base_dir", "source", xy=False)
+
+    def test_custom_tilemap_service(self):
+        """
+        Test custom tilemap service.
+
+        This function tests the customization of tilemap service using customTMS method in the BaseMapper class.
+        It verifies if the custom tilemap service URL is correctly set and if the source is updated accordingly.
+
+        Test Cases:
+        - Test if the source is set to 'custom' after customizing the tilemap service.
+        - Test if the custom tilemap service URL is correctly set in the sources dictionary.
+
+        """
+        basemap = self.create_basemap()
+        basemap.customTMS("https://basemap.nationalmap.gov/ArcGIS/rest/services/USGSTopo/MapServer/tile/{z}/{y}/{x}")
+        assert basemap.source == "custom"
+
+        tms = {'name': 'custom', 
+               'url': 'https://basemap.nationalmap.gov/ArcGIS/rest/services/USGSTopo/MapServer/tile/%s', 
+               'suffix': 'jpg',
+                'source': 'custom'}       
+        assert basemap.sources["custom"] == tms
+
+    def test_imagery_sources(self):
+        """
+        Test case for verifying the sources of imagery basemaps.
+
+        This test function creates basemaps with different sources and asserts that
+        the basemap source attribute matches the expected source.
+
+        Args:
+            self: The instance of the test class.
+
+        Returns:
+            None
+        """
+
+        basemap =self.create_basemap( source="bing")
+        assert basemap.source == "bing"
+        basemap = self.create_basemap(source= "esri")
+        assert basemap.source == "esri"
+        basemap = self.create_basemap( source="google")
+        assert basemap.source == "google"
+        basemap =self.create_basemap(  source="oam")
+        assert basemap.source == "oam"


### PR DESCRIPTION
Bugfix: handle non-string boundary inputs

- Add a check to ensure the `boundary` value is a string before attempting string operations
- Raise a ValueError with an appropriate error message when `boundary` is not a string
- This change prevents a TypeError from being raised when trying to process non-string `boundary` values